### PR TITLE
Set LC_ALL=C in provider test

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -75,6 +75,8 @@ func TestCall(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 		Convey("If it returns exit code > 0, return stderr", func() {
+			err := os.Setenv("LC_ALL", "C")
+			So(err, ShouldBeNil)
 			out, err := Call("ls", "README.notafile")
 
 			So(out, ShouldBeBlank)


### PR DESCRIPTION
Currently provider tests fail on non-C locale due to mismatch in the
error message. For example in pl_PL:

```
Failures:

  * /home/divide/projekty/conjur/summon/provider/provider_test.go 
  Line 83:
  Expected 'ls: nie ma dostępu do README.notafile: Nie ma takiego pliku ani katalogu
  ' to contain substring 'No such file or directory' (but it didn't)!
```

Change the environment of the test to make sure locale is C for the test.