### PR TITLE
Environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ the secrets stored in temp files and in the Python process environment are gone.
 
     This flag can be useful for when you have secrets that you don't need access to for development. For example API keys for monitoring tools. This flag can be used multiple times.
 
+* `-e, --environment` Specify section (environment) to parse from secret YAML
+
+    This flag specifies which specific environment/section to parse from the secrets YAML file (or string). In addition, it will also enable the usage of a `common` section which will be inherited by other sections/environments. In other words, if your `secrets.yaml` looks something like this:
+
+```yaml
+common:
+  DB_USER: db-user
+  DB_NAME: db-name
+  DB_HOST: db-host.example.com
+
+staging:
+  DB_PASS: some_password
+
+production:
+  DB_PASS: other_password
+```
+
+Doing something along the lines of: `summon -f secrets.yaml -e staging printenv | grep DB_`, `summon` will populate `DB_USER`, `DB_NAME`, `DB_HOST` with values from `common` and set `DB_PASS` to `some_password`.
+
 View help and all flags with `summon -h`.
 
 ### env-file

--- a/command/action.go
+++ b/command/action.go
@@ -59,9 +59,9 @@ func runAction(ac *ActionConfig) (string, error) {
 
 	switch ac.YamlInline {
 	case "":
-		secrets, err = secretsyml.ParseFromFile(ac.Filepath, ac.Subs)
+		secrets, err = secretsyml.ParseFromFile(ac.Filepath, ac.Environment, ac.Subs)
 	default:
-		secrets, err = secretsyml.ParseFromString(ac.YamlInline, ac.Subs)
+		secrets, err = secretsyml.ParseFromString(ac.YamlInline, ac.Environment, ac.Subs)
 	}
 
 	if err != nil {

--- a/command/action_test.go
+++ b/command/action_test.go
@@ -27,7 +27,7 @@ func TestRunAction(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
-		Convey("Errors when fetching keys keys return error", func() {
+		Convey("Errors when fetching keys return error", func() {
 			_, err := runAction(&ActionConfig{
 				Args:       []string{"printenv", "MYVAR"}, // args
 				Provider:   providerPath,                  // provider
@@ -39,7 +39,7 @@ func TestRunAction(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Errors when fetching keys keys don't return error if ignored", func() {
+		Convey("Errors when fetching keys don't return error if ignored", func() {
 			out, err := runAction(&ActionConfig{
 				Args:       []string{"printenv", "MYVAR"},
 				Provider:   providerPath,

--- a/command/action_test.go
+++ b/command/action_test.go
@@ -15,39 +15,39 @@ func TestRunAction(t *testing.T) {
 		providerPath := path.Join(os.Getenv("PWD"), "testprovider.sh")
 
 		Convey("Passing in secrets.yml via --yaml", func() {
-			out, err := runAction(
-				[]string{"printenv", "MYVAR"},
-				providerPath,
-				"",
-				"MYVAR: !var somesecret/on/a/path",
-				map[string]string{},
-				[]string{},
-			)
+			out, err := runAction(&ActionConfig{
+				Args:       []string{"printenv", "MYVAR"},
+				Provider:   providerPath,
+				Filepath:   "",
+				YamlInline: "MYVAR: !var somesecret/on/a/path",
+				Subs:       map[string]string{},
+				Ignores:    []string{},
+			})
 			So(out, ShouldEqual, "mysecret\n")
 			So(err, ShouldBeNil)
 		})
 
 		Convey("Errors when fetching keys keys return error", func() {
-			_, err := runAction(
-				[]string{"printenv", "MYVAR"},
-				providerPath,
-				"",
-				"MYVAR: !var error",
-				map[string]string{},
-				[]string{},
-			)
+			_, err := runAction(&ActionConfig{
+				Args:       []string{"printenv", "MYVAR"}, // args
+				Provider:   providerPath,                  // provider
+				Filepath:   "",                            // filepath
+				YamlInline: "MYVAR: !var error",           // yaml inline
+				Subs:       map[string]string{},           // subs
+				Ignores:    []string{},                    // ignore
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Errors when fetching keys keys don't return error if ignored", func() {
-			out, err := runAction(
-				[]string{"printenv", "MYVAR"},
-				providerPath,
-				"",
-				"{MYVAR: !var test, ERR: !var error}",
-				map[string]string{},
-				[]string{"ERR"},
-			)
+			out, err := runAction(&ActionConfig{
+				Args:       []string{"printenv", "MYVAR"},
+				Provider:   providerPath,
+				Filepath:   "",
+				YamlInline: "{MYVAR: !var test, ERR: !var error}",
+				Subs:       map[string]string{},
+				Ignores:    []string{"ERR"},
+			})
 			So(err, ShouldBeNil)
 			So(out, ShouldEqual, "mysecret\n")
 		})

--- a/command/flags.go
+++ b/command/flags.go
@@ -10,6 +10,10 @@ var Flags = []cli.Flag{
 		Usage: "Path to provider for fetching secrets",
 	},
 	cli.StringFlag{
+		Name:  "e, environment",
+		Usage: "Specify section/environment to parse from secrets.yaml",
+	},
+	cli.StringFlag{
 		Name:  "f",
 		Value: "secrets.yml",
 		Usage: "Path to secrets.yml",

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestParseFromString(t *testing.T) {
+	testEnv := ""
+
 	Convey("Given a string in secrets.yml format", t, func() {
 		input := `
     SENTRY_API_KEY: !var $env/sentry/api_key
@@ -17,7 +19,7 @@ func TestParseFromString(t *testing.T) {
     INT: 27
     `
 		Convey("It should correctly identify the types from tags", func() {
-			parsed, err := ParseFromString(input, map[string]string{"env": "prod"})
+			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
 			So(err, ShouldBeNil)
 
 			spec := parsed["SENTRY_API_KEY"]

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -1,23 +1,23 @@
 package secretsyml
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestParseFromString(t *testing.T) {
-	testEnv := ""
-
 	Convey("Given a string in secrets.yml format", t, func() {
+		testEnv := ""
 		input := `
-    SENTRY_API_KEY: !var $env/sentry/api_key
-    PRIVATE_KEY_FILE: !file:var $env/aws/ec2/private_key
-    PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
-    SOME_FILE: !file my content
-    RAILS_ENV: $env
-    FLOAT: 27.1111
-    INT: 27
-    `
+SENTRY_API_KEY: !var $env/sentry/api_key
+PRIVATE_KEY_FILE: !file:var $env/aws/ec2/private_key
+PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
+SOME_FILE: !file my content
+RAILS_ENV: $env
+FLOAT: 27.1111
+INT: 27`
 		Convey("It should correctly identify the types from tags", func() {
 			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
 			So(err, ShouldBeNil)
@@ -52,6 +52,95 @@ func TestParseFromString(t *testing.T) {
 			So(found, ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27")
+		})
+	})
+
+	Convey("Given a string with environment in secrets.yml format", t, func() {
+		testEnv := "TestEnvironment"
+		input := `TestEnvironment:
+  SENTRY_API_KEY: !var $env/sentry/api_key
+  PRIVATE_KEY_FILE: !file:var $env/aws/ec2/private_key
+  PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
+  SOME_FILE: !file my content
+  RAILS_ENV: $env
+  FLOAT: 27.1111
+  INT: 27`
+
+		Convey("It should correctly identify the types from tags", func() {
+			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
+			So(err, ShouldBeNil)
+
+			spec := parsed["SENTRY_API_KEY"]
+			So(spec.IsVar(), ShouldBeTrue)
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsLiteral(), ShouldBeFalse)
+
+			// order of tag declaration shouldn't matter
+			for _, key := range []string{"PRIVATE_KEY_FILE", "PRIVATE_KEY_FILE2"} {
+				spec = parsed[key]
+				So(spec.IsVar(), ShouldBeTrue)
+				So(spec.IsFile(), ShouldBeTrue)
+				So(spec.IsLiteral(), ShouldBeFalse)
+			}
+
+			spec = parsed["SOME_FILE"]
+			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsFile(), ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeFalse)
+
+			spec = parsed["RAILS_ENV"]
+			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsLiteral(), ShouldBeTrue)
+
+			_, found := parsed["FLOAT"]
+			So(found, ShouldBeFalse)
+
+			spec, found = parsed["INT"]
+			So(found, ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "27")
+		})
+	})
+
+	Convey("Given an incorrect/unavailable environment", t, func() {
+		testEnv := "TestEnvironment"
+		input := `common:
+  SOMETHING_COMMON: should-be-available
+  RAILS_ENV: should-be-overridden
+
+MissingEnvironment:
+  RAILS_ENV: $env`
+		Convey("It should error", func() {
+			_, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
+			So(err, ShouldNotBeNil)
+
+			errMessage := fmt.Sprintf("No such environment '%v' found in secrets file", testEnv)
+			So(err.Error(), ShouldEqual, errMessage)
+		})
+	})
+
+	Convey("Given a common section and environment ", t, func() {
+		testEnv := "TestEnvironment"
+		input := `common:
+  SOMETHING_COMMON: should-be-available
+  RAILS_ENV: should-be-overridden
+
+TestEnvironment:
+  RAILS_ENV: $env`
+
+		Convey("It should merge the environment section with common section", func() {
+			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
+			So(err, ShouldBeNil)
+
+			spec := parsed["SOMETHING_COMMON"]
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "should-be-available")
+
+			// RAILS_ENV should be overridden (specific section takes precedence)
+			spec = parsed["RAILS_ENV"]
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "prod")
 		})
 	})
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.0"
+const VERSION = "0.5.0"


### PR DESCRIPTION
Hi there!

This PR introduces some new functionality:

- It allows you to specify a `-e` or `--environment` flag to parse a specific section from the secrets YAML. If this section does not exist, `summon` will exit with 1 (as expected). Old functionality still remains - it is not _required_ to use the `environment` bit.
- Added parsing of a `common` section from the YAML. Having a `common` section allows other sections to inherit env vars from it (primary sections will override env vars in `common`). Unfortunately YAML's inheritance is more akin to a map merge, so we have to resort to our own merge-handling.
- Expanded tests
- Cleaned up runAction() signature as it was getting a bit unruly after adding 'env'; replaced the parameters with a single `ActionConfig` struct; besides looking a bit cleaner, it also has the benefit of being less guess work as to what each parameter means, both in tests and in-code).
- Upped minor version
- Forgot to expand README, will do that in a quick follow up commit

Some other quick notes:

To avoid a slew of type assertions and various if/else blocks (due to the new map becoming `map[string]interface{}`, I opted to separate `parse()` into two additional functions: `parseRegular()` and `parseEnvironment`. I feel that this is a bit cleaner than expanding `parse()` to handle both cases - but please let me know if you don't like the approach.

Please let me know what you think!

cc @jonDowdle