### PR TITLE
Add support for bool values in secretsyaml

### DIFF
--- a/secretsyml/secretsyml.go
+++ b/secretsyml/secretsyml.go
@@ -53,14 +53,14 @@ func (s *SecretSpec) IsLiteral() bool {
 type SecretsMap map[string]SecretSpec
 
 func (spec *SecretSpec) SetYAML(tag string, value interface{}) bool {
-	r, _ := regexp.Compile("(var|file|str|int)")
+	r, _ := regexp.Compile("(var|file|str|int|bool)")
 	tags := r.FindAllString(tag, -1)
 	if len(tags) == 0 {
 		return false
 	}
 	for _, t := range tags {
 		switch t {
-		case "str", "int":
+		case "str", "int", "bool":
 			spec.Tags = append(spec.Tags, Literal)
 		case "file":
 			spec.Tags = append(spec.Tags, File)
@@ -75,6 +75,8 @@ func (spec *SecretSpec) SetYAML(tag string, value interface{}) bool {
 		spec.Path = s
 	} else if s, ok := value.(int); ok {
 		spec.Path = strconv.Itoa(s)
+	} else if s, ok := value.(bool); ok {
+		spec.Path = strconv.FormatBool(s)
 	} else {
 		return false
 	}

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -17,7 +17,8 @@ PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
 SOME_FILE: !file my content
 RAILS_ENV: $env
 FLOAT: 27.1111
-INT: 27`
+INT: 27
+BOOL: true`
 		Convey("It should correctly identify the types from tags", func() {
 			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
 			So(err, ShouldBeNil)
@@ -52,6 +53,11 @@ INT: 27`
 			So(found, ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27")
+
+			spec, found = parsed["BOOL"]
+			So(found, ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "true")
 		})
 	})
 
@@ -64,7 +70,8 @@ INT: 27`
   SOME_FILE: !file my content
   RAILS_ENV: $env
   FLOAT: 27.1111
-  INT: 27`
+  INT: 27
+  BOOL: true`
 
 		Convey("It should correctly identify the types from tags", func() {
 			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
@@ -100,6 +107,11 @@ INT: 27`
 			So(found, ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27")
+
+			spec, found = parsed["BOOL"]
+			So(found, ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "true")
 		})
 	})
 


### PR DESCRIPTION
Not sure if this is intended behavior but we noticed that bools get left behind if not quoted in the secrets yaml file. Our project had a need to accept bools unquoted, so this adds support for that.