### PR TITLE
Dselans/common aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the secrets stored in temp files and in the Python process environment are gone.
 
 * `-e, --environment` Specify section (environment) to parse from secret YAML
 
-    This flag specifies which specific environment/section to parse from the secrets YAML file (or string). In addition, it will also enable the usage of a `common` section which will be inherited by other sections/environments. In other words, if your `secrets.yaml` looks something like this:
+    This flag specifies which specific environment/section to parse from the secrets YAML file (or string). In addition, it will also enable the usage of a `common` (or `default`) section which will be inherited by other sections/environments. In other words, if your `secrets.yaml` looks something like this:
 
 ```yaml
 common:
@@ -122,6 +122,8 @@ production:
 ```
 
 Doing something along the lines of: `summon -f secrets.yaml -e staging printenv | grep DB_`, `summon` will populate `DB_USER`, `DB_NAME`, `DB_HOST` with values from `common` and set `DB_PASS` to `some_password`.
+
+Note: `default` is an alias for `common` section. You can use either one.
 
 View help and all flags with `summon -h`.
 

--- a/secretsyml/secretsyml.go
+++ b/secretsyml/secretsyml.go
@@ -53,14 +53,14 @@ func (s *SecretSpec) IsLiteral() bool {
 type SecretsMap map[string]SecretSpec
 
 func (spec *SecretSpec) SetYAML(tag string, value interface{}) bool {
-	r, _ := regexp.Compile("(var|file|str|int)")
+	r, _ := regexp.Compile("(var|file|str|int|bool)")
 	tags := r.FindAllString(tag, -1)
 	if len(tags) == 0 {
 		return false
 	}
 	for _, t := range tags {
 		switch t {
-		case "str", "int":
+		case "str", "int", "bool":
 			spec.Tags = append(spec.Tags, Literal)
 		case "file":
 			spec.Tags = append(spec.Tags, File)
@@ -75,6 +75,8 @@ func (spec *SecretSpec) SetYAML(tag string, value interface{}) bool {
 		spec.Path = s
 	} else if s, ok := value.(int); ok {
 		spec.Path = strconv.Itoa(s)
+	} else if s, ok := value.(bool); ok {
+		spec.Path = strconv.FormatBool(s)
 	} else {
 		return false
 	}

--- a/secretsyml/secretsyml.go
+++ b/secretsyml/secretsyml.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 )
 
+var COMMON_SECTIONS = []string{"common", "default"}
+
 type YamlTag uint8
 
 const (
-	COMMON_SECTION = "common"
-
 	File YamlTag = iota
 	Var
 	Literal
@@ -129,9 +129,11 @@ func parseEnvironment(ymlContent, env string, subs map[string]string) (SecretsMa
 		secretsMap[i] = spec
 	}
 
-	// parse and merge optional 'common' section with secretsMap
-	if _, ok := out[COMMON_SECTION]; ok {
-		return parseAndMergeCommon(out[COMMON_SECTION], secretsMap, subs)
+	// parse and merge optional 'common/default' section with secretsMap
+	for _, section := range COMMON_SECTIONS {
+		if _, ok := out[section]; ok {
+			return parseAndMergeCommon(out[section], secretsMap, subs)
+		}
 	}
 
 	return secretsMap, nil

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -17,7 +17,8 @@ PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
 SOME_FILE: !file my content
 RAILS_ENV: $env
 FLOAT: 27.1111
-INT: 27`
+INT: 27
+BOOL: true`
 		Convey("It should correctly identify the types from tags", func() {
 			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
 			So(err, ShouldBeNil)
@@ -52,6 +53,11 @@ INT: 27`
 			So(found, ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27")
+
+			spec, found = parsed["BOOL"]
+			So(found, ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "true")
 		})
 	})
 
@@ -64,7 +70,8 @@ INT: 27`
   SOME_FILE: !file my content
   RAILS_ENV: $env
   FLOAT: 27.1111
-  INT: 27`
+  INT: 27
+  BOOL: true`
 
 		Convey("It should correctly identify the types from tags", func() {
 			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
@@ -100,6 +107,11 @@ INT: 27`
 			So(found, ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27")
+
+			spec, found = parsed["BOOL"]
+			So(found, ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "true")
 		})
 	})
 

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -155,4 +155,30 @@ TestEnvironment:
 			So(spec.Path, ShouldEqual, "prod")
 		})
 	})
+
+	// Verify that 'default' works in addition to 'common'
+	Convey("Given a default section and environment ", t, func() {
+		testEnv := "TestEnvironment"
+		input := `default:
+  SOMETHING_COMMON: should-be-available
+  RAILS_ENV: should-be-overridden
+
+TestEnvironment:
+  RAILS_ENV: $env`
+
+		Convey("It should merge the environment section with default section", func() {
+			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
+			So(err, ShouldBeNil)
+
+			spec := parsed["SOMETHING_COMMON"]
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "should-be-available")
+
+			// RAILS_ENV should be overridden (specific section takes precedence)
+			spec = parsed["RAILS_ENV"]
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "prod")
+		})
+	})
+
 }


### PR DESCRIPTION
Hey folks,

We had a unique requirement that the top-level common section be called 'default' instead. This required a very minor code change to allow the `COMMON_SECTION` to turn into `COMMON_SECTIONS`.

Test updated (copy/paste from another test).