### PR TITLE
Don't rely on executable bit on the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+#v0.6.4
+* Don't rely on executable bit on the provider; instead provide descriptive error if it fails to run - [Issue #40](https://github.com/conjurinc/summon/issues/40)
+
 #v0.6.3
 * Summon now passes the child exit status to the caller - [PR #39](https://github.com/conjurinc/summon/pull/39)
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,13 +36,9 @@ func Resolve(providerArg string) (string, error) {
 		return "", fmt.Errorf("Could not resolve a provider!")
 	}
 
-	info, err := os.Stat(provider)
+	_, err := os.Stat(provider)
 	if err != nil {
 		return "", err
-	}
-
-	if (info.Mode() & 0111) == 0 {
-		return "", fmt.Errorf("%s is not executable", provider)
 	}
 
 	return provider, nil
@@ -62,7 +58,11 @@ func Call(provider, specPath string) (string, error) {
 	err := cmd.Run()
 
 	if err != nil {
-		return "", fmt.Errorf(stdErr.String())
+		errstr := err.Error()
+		if stdErr.Len() > 0 {
+			errstr += ": " + strings.TrimSpace(stdErr.String())
+		}
+		return "", fmt.Errorf(errstr)
 	}
 
 	return strings.TrimSpace(stdOut.String()), nil

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -82,5 +82,13 @@ func TestCall(t *testing.T) {
 			So(out, ShouldBeBlank)
 			So(err.Error(), ShouldContainSubstring, "No such file or directory")
 		})
+		Convey("If it can't be executed, returns a descriptive error", func() {
+			err := os.Setenv("LC_ALL", "C")
+			So(err, ShouldBeNil)
+			out, err := Call("/etc/passwd", "foo")
+
+			So(out, ShouldBeBlank)
+			So(err.Error(), ShouldContainSubstring, "permission denied")
+		})
 	})
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3"
+const VERSION = "0.6.4"


### PR DESCRIPTION
Instead provide descriptive error if it fails to run.
Fixes issue #40